### PR TITLE
start json-eval

### DIFF
--- a/json-eval/CMakeLists.txt
+++ b/json-eval/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(src)
+

--- a/json-eval/src/CMakeLists.txt
+++ b/json-eval/src/CMakeLists.txt
@@ -1,0 +1,40 @@
+find_package(FLEX)
+if(NOT FLEX_FOUND)
+    message(FATAL_ERROR "you need to install flex first")
+endif()
+find_package(BISON)
+if(NOT BISON_FOUND)
+    message(FATAL_ERROR "you need to install bison first")
+endif()
+
+# json-eval parser/scanner with flex/bison
+BISON_TARGET(hvmlJsonEvalParser
+             hvml_je_parser.y
+             ${CMAKE_CURRENT_BINARY_DIR}/hvml_je_parser.tab.c
+)
+FLEX_TARGET(hvmlJsonEvalScanner
+            hvml_je_scanner.l
+            ${CMAKE_CURRENT_BINARY_DIR}/hvml_je_scanner.c
+            COMPILE_FLAGS "--header-file=${CMAKE_CURRENT_BINARY_DIR}/hvml_je_scanner.lex.h"
+)
+ADD_FLEX_BISON_DEPENDENCY(hvmlJsonEvalScanner hvmlJsonEvalParser)
+
+
+set(hvml_je_src
+    ${BISON_hvmlJsonEvalParser_OUTPUTS}
+    ${FLEX_hvmlJsonEvalScanner_OUTPUTS}
+)
+
+# static
+add_library(hvml_je_static STATIC ${hvml_je_src})
+target_include_directories(hvml_je_static PUBLIC
+                           "${PROJECT_SOURCE_DIR}/include"
+)
+set_target_properties(hvml_je_static PROPERTIES OUTPUT_NAME hvml_je)
+
+# shared
+add_library(hvml_je SHARED ${hvml_je_src})
+target_include_directories(hvml_je PUBLIC
+                           "${PROJECT_SOURCE_DIR}/include"
+)
+

--- a/json-eval/src/CMakeLists.txt
+++ b/json-eval/src/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 BISON_TARGET(hvmlJsonEvalParser
              hvml_je_parser.y
              ${CMAKE_CURRENT_BINARY_DIR}/hvml_je_parser.tab.c
+            COMPILE_FLAGS "--graph=${CMAKE_CURRENT_BINARY_DIR}/hvml_je_parser.tab.gv"
 )
 FLEX_TARGET(hvmlJsonEvalScanner
             hvml_je_scanner.l

--- a/json-eval/src/hvml_je_parser.y
+++ b/json-eval/src/hvml_je_parser.y
@@ -38,11 +38,13 @@ void yyerror(YYLTYPE *yylloc, hvml_dom_t **pdom, void *arg, char const *s);
 %token <str> TEXT LINTEGER LTOKEN LSTR
 %token DOLAR1 DOLAR2
 
+%destructor { free($$); } <str>
+
 %% /* The grammar follows. */
 
 input:
   %empty
-| input TEXT
+| input TEXT  { D("text: [%s]", $2); free($2); }
 | input jee
 | input error { return -1; }
 ;
@@ -50,9 +52,9 @@ input:
 jee:
   DOLAR1 jae
 | DOLAR2 jae '}'
-| LINTEGER
-| '"'  LSTR '"'
-| '\'' LSTR '\''
+| LINTEGER           { D("integer: [%s]", $1); free($1); }
+| '"'  LSTR '"'      { D("str: [%s]", $2); free($2); }
+| '\'' LSTR '\''     { D("str: [%s]", $2); free($2); }
 ;
 
 jae:
@@ -63,17 +65,17 @@ jae:
 ;
 
 var:
-  '?'
-| '@'
-| '#'
-| '%'
-| ':'
-| LINTEGER
-| LTOKEN
+  '?'                { D("?"); }
+| '@'                { D("@"); }
+| '#'                { D("#"); }
+| '%'                { D("%%"); }
+| ':'                { D(":"); }
+| LINTEGER           { D("integer: [%s]", $1); free($1); }
+| LTOKEN             { D("token: [%s]", $1); free($1); }
 ;
 
 key:
-  LTOKEN
+  LTOKEN             { D("token: [%s]", $1); free($1); }
 ;
 
 args:

--- a/json-eval/src/hvml_je_parser.y
+++ b/json-eval/src/hvml_je_parser.y
@@ -35,8 +35,8 @@ void yyerror(YYLTYPE *yylloc, hvml_dom_t **pdom, void *arg, char const *s);
 
 %union { char            *str; }
 
-%token <str> TEXT LINTEGER LTOKEN LSTR
-%token DOLAR1 DOLAR2 SPACE
+%token <str> TEXT LINTEGER LTOKEN LSTR SPACE
+%token DOLAR1 DOLAR2
 
 %destructor { free($$); } <str>
 
@@ -46,21 +46,24 @@ input:
   %empty
 | input TEXT  { D("text: [%s]", $2); free($2); }
 | input jee
+| input SPACE { D("space: [%s]", $2); free($2); }
 | input error { return -1; }
 ;
 
 jee:
-  DOLAR1 jae ows
-| DOLAR2 ows jae ows '}' ows
-| LINTEGER ows       { D("integer: [%s]", $1); free($1); }
-| '"'  LSTR '"' ows  { D("str: [%s]", $2); free($2); }
-| '\'' LSTR '\'' ows { D("str: [%s]", $2); free($2); }
+  DOLAR1 jae
+| DOLAR2 ows jae ows '}'
+| LINTEGER           { D("integer: [%s]", $1); free($1); }
+| '"'  LSTR '"'      { D("str: [%s]", $2); free($2); }
+| '\'' LSTR '\''     { D("str: [%s]", $2); free($2); }
 ;
 
 jae:
   var
 | jae '.' key
+| jae '(' ows ')'
 | jae '(' ows args ows ')'
+| jae '<' ows '>'
 | jae '<' ows args ows '>'
 | jae '[' ows jee ows ']'
 ;
@@ -80,18 +83,13 @@ key:
 ;
 
 args:
-  %empty
-| jees
-;
-
-jees:
   jee
-| jees ows ',' ows jee
+| args ows ',' ows jee
 ;
 
 ows:
   %empty
-| ows SPACE
+| ows SPACE          { D("space: [%s]", $2); free($2); }
 ;
 
 %%

--- a/json-eval/src/hvml_je_parser.y
+++ b/json-eval/src/hvml_je_parser.y
@@ -1,0 +1,113 @@
+%code top {
+    // code top========================
+}
+
+%code requires {
+    // code requires===================
+#include "hvml/hvml_dom.h"
+#include "hvml/hvml_string.h"
+
+#include <stdio.h>
+}
+
+%code {
+    // code ===========================
+#include "hvml/hvml_log.h"
+#include "hvml_je_scanner.lex.h"
+
+#include <ctype.h>
+#include <math.h>
+#include <string.h>
+void yyerror(YYLTYPE *yylloc, hvml_dom_t **pdom, void *arg, char const *s);
+
+}
+
+/* Bison declarations. */
+%require "3.4"
+%define api.prefix {hvml_je_yy}
+%define api.pure full
+%define api.token.prefix {TOK_HVML_JE_}
+%define locations
+%define parse.error verbose
+
+%parse-param { hvml_dom_t **pdom }
+%param { void *arg }
+
+%union { char            *str; }
+
+%token <str> TEXT LINTEGER LTOKEN LSTR
+%token DOLAR1 DOLAR2
+
+%% /* The grammar follows. */
+
+input:
+  %empty
+| input TEXT
+| input jee
+| input error { return -1; }
+;
+
+jee:
+  DOLAR1 jae
+| DOLAR2 jae '}'
+| LINTEGER
+| '"'  LSTR '"'
+| '\'' LSTR '\''
+;
+
+jae:
+  var
+| jae '.' key
+| jae '(' args ')'
+| jae '[' jee ']'
+;
+
+var:
+  '?'
+| '@'
+| '#'
+| '%'
+| ':'
+| LINTEGER
+| LTOKEN
+;
+
+key:
+  LTOKEN
+;
+
+args:
+  %empty
+| jees
+;
+
+jees:
+  jee
+| jees ',' jee
+;
+
+
+%%
+
+
+/* Called by yyparse on error. */
+void yyerror(YYLTYPE *yylloc, hvml_dom_t **pdom, void *arg, char const *s) {
+  (void)pdom;
+  (void)arg;
+  (void)yylloc;
+  D("%s: (%d,%d)->(%d,%d)", s,
+    yylloc->first_line, yylloc->first_column,
+    yylloc->last_line, yylloc->last_column);
+}
+
+int dummy(hvml_dom_t **pdom, FILE *in) {
+  yyscan_t arg = {0};
+  hvml_je_yylex_init(&arg);
+  hvml_je_yyset_in(in, arg);
+  hvml_je_yyset_debug(1, arg);
+  int ret =hvml_je_yyparse(pdom, arg);
+  D("ret:%d", ret);
+  hvml_je_yylex_destroy(arg);
+  return ret ? 1 : 0;
+}
+

--- a/json-eval/src/hvml_je_parser.y
+++ b/json-eval/src/hvml_je_parser.y
@@ -36,7 +36,7 @@ void yyerror(YYLTYPE *yylloc, hvml_dom_t **pdom, void *arg, char const *s);
 %union { char            *str; }
 
 %token <str> TEXT LINTEGER LTOKEN LSTR
-%token DOLAR1 DOLAR2
+%token DOLAR1 DOLAR2 SPACE
 
 %destructor { free($$); } <str>
 
@@ -50,18 +50,19 @@ input:
 ;
 
 jee:
-  DOLAR1 jae
-| DOLAR2 jae '}'
-| LINTEGER           { D("integer: [%s]", $1); free($1); }
-| '"'  LSTR '"'      { D("str: [%s]", $2); free($2); }
-| '\'' LSTR '\''     { D("str: [%s]", $2); free($2); }
+  DOLAR1 jae ows
+| DOLAR2 ows jae ows '}' ows
+| LINTEGER ows       { D("integer: [%s]", $1); free($1); }
+| '"'  LSTR '"' ows  { D("str: [%s]", $2); free($2); }
+| '\'' LSTR '\'' ows { D("str: [%s]", $2); free($2); }
 ;
 
 jae:
   var
 | jae '.' key
-| jae '(' args ')'
-| jae '[' jee ']'
+| jae '(' ows args ows ')'
+| jae '<' ows args ows '>'
+| jae '[' ows jee ows ']'
 ;
 
 var:
@@ -85,9 +86,13 @@ args:
 
 jees:
   jee
-| jees ',' jee
+| jees ows ',' ows jee
 ;
 
+ows:
+  %empty
+| ows SPACE
+;
 
 %%
 

--- a/json-eval/src/hvml_je_scanner.l
+++ b/json-eval/src/hvml_je_scanner.l
@@ -1,0 +1,147 @@
+%{
+#include "hvml/hvml_log.h"
+#include "hvml/hvml_utf8.h"
+#include "hvml_je_parser.tab.h"
+#include <stdio.h>
+
+#define YYSTYPE       HVML_JE_YYSTYPE
+#define YYLTYPE       HVML_JE_YYLTYPE
+
+#define S()                                   \
+do {                                                \
+    for (int i=0; i<yyleng; ++i) {                  \
+        const char c = yytext[i];                   \
+        if (c=='\n') {                              \
+            yylloc->last_line    += 1;              \
+            yylloc->last_column   = 0;              \
+        } else {                                    \
+            yylloc->last_column  += 1;              \
+        }                                           \
+    }                                               \
+    yylloc->first_line   = yylloc->last_line;       \
+    yylloc->first_column = yylloc->last_column;     \
+} while (0)
+
+#define PUSH_STATE(state)      yy_push_state(state, yyscanner)
+#define POP_STATE()            yy_pop_state(yyscanner)
+
+#define CHG_STATE(state)                \
+do {                                    \
+    yy_pop_state(yyscanner);            \
+    yy_push_state(state, yyscanner);    \
+} while (0)
+
+#define TOP_STATE(top)                  \
+do {                                    \
+    yy_push_state(INITIAL, yyscanner);  \
+    top = yy_top_state(yyscanner);      \
+    yy_pop_state(yyscanner);            \
+} while (0)
+
+#define UNPUT()                                 \
+do {                                            \
+    while (yyleng) unput(yytext[yyleng-1]);     \
+} while (0)
+
+%}
+
+%option prefix="hvml_je_yy"
+%option bison-bridge bison-locations
+%option reentrant
+%option noyywrap
+%option noinput nounput
+%option debug verbose
+%option stack
+%option unput
+%option nodefault
+%option warn
+%option perf-report
+%option 8bit
+
+LTOKEN   [A-Za-z_][A-Za-z0-9_]*
+LINTEGER 0|([1-9][0-9]*)
+
+%x DOLAR VARDONE ARGS STR STR1
+
+%%
+<<EOF>> { int state; TOP_STATE(state);
+          if (state != INITIAL) return -1;
+          yyterminate(); }
+"$"     { S();
+          PUSH_STATE(DOLAR);
+          return TOK_HVML_JE_DOLAR1; }
+"{$"    { S();
+          PUSH_STATE(DOLAR);
+          return TOK_HVML_JE_DOLAR2; }
+[^${]+  { S();
+          yylval->str = yytext;
+          return TOK_HVML_JE_TEXT; }
+.       { return -1; }
+
+<DOLAR>"}"          { S();
+                      POP_STATE();
+                      return *yytext; }
+<DOLAR>[?@#%:]      { S();
+                      return *yytext; }
+<DOLAR>{LTOKEN}     { S();
+                      yylval->str = yytext;
+                      return TOK_HVML_JE_LTOKEN; }
+<DOLAR>{LINTEGER}   { S();
+                      yylval->str = yytext;
+                      return TOK_HVML_JE_LINTEGER; }
+<DOLAR>[.]        { S();
+                      return *yytext; }
+<DOLAR>[[(<]      { S();
+                      return *yytext; }
+<DOLAR>[}]        { S();
+                      POP_STATE();
+                      return *yytext; }
+<DOLAR>["]           { S();
+                      PUSH_STATE(STR);
+                      return *yytext; }
+<DOLAR>[']           { S();
+                      PUSH_STATE(STR1);
+                      return *yytext; }
+<DOLAR>[,]           { S();
+                      return *yytext; }
+<DOLAR>"$"           { S();
+                      PUSH_STATE(DOLAR);
+                      return TOK_HVML_JE_DOLAR1; }
+<DOLAR>"{$"          { S();
+                      PUSH_STATE(DOLAR);
+                      return TOK_HVML_JE_DOLAR2; }
+<DOLAR>[])>]         { S();
+                      return *yytext; }
+<DOLAR>.|\n          { unput(*yytext);
+                       POP_STATE(); }
+
+    /* no escape support yet */
+<STR>["]        { S();
+                  POP_STATE();
+                  return *yytext; }
+<STR>[^"]+      { S();
+                  yylval->str = yytext;
+                  return TOK_HVML_JE_LSTR; }
+
+    /* no escape support yet */
+<STR1>[']       { S();
+                  POP_STATE();
+                  return *yytext; }
+<STR1>[^']+     { S();
+                  yylval->str = yytext;
+                  return TOK_HVML_JE_LSTR; }
+
+%%
+
+// int hvml_parser_gen_dom(hvml_dom_t **pdom, FILE *in) {
+//   // yylloc->first_line = yylloc->last_line = 1;
+//   // yylloc->first_column = yylloc->last_column = 0;
+//   yyscan_t arg = {0};
+//   hvml_yylex_init(&arg);
+//   hvml_yyset_in(in, arg);
+//   hvml_yyset_debug(1, arg);
+//   int ret =hvml_yyparse(pdom, arg);
+//   hvml_yylex_destroy(arg);
+//   return ret ? 1 : 0;
+// }
+

--- a/json-eval/src/hvml_je_scanner.l
+++ b/json-eval/src/hvml_je_scanner.l
@@ -58,10 +58,10 @@ do {                                            \
 %option perf-report
 %option 8bit
 
-LTOKEN   [A-Za-z_][A-Za-z0-9_]*
+LTOKEN   [A-Za-z_]([^[:cntrl:][:punct:][:space:]]|[_-])*
 LINTEGER 0|([1-9][0-9]*)
 
-%x DOLAR VARDONE ARGS STR STR1
+%x DOLAR STR STR1
 
 %%
 <<EOF>> { int state; TOP_STATE(state);
@@ -76,7 +76,8 @@ LINTEGER 0|([1-9][0-9]*)
 [^${]+  { S();
           yylval->str = strdup(yytext);
           return TOK_HVML_JE_TEXT; }
-.       { return -1; }
+.       { S();
+          return *yytext; }
 
 <DOLAR>"}"          { S();
                       POP_STATE();
@@ -92,9 +93,6 @@ LINTEGER 0|([1-9][0-9]*)
 <DOLAR>[.]        { S();
                       return *yytext; }
 <DOLAR>[[(<]      { S();
-                      return *yytext; }
-<DOLAR>[}]        { S();
-                      POP_STATE();
                       return *yytext; }
 <DOLAR>["]           { S();
                       PUSH_STATE(STR);
@@ -113,6 +111,7 @@ LINTEGER 0|([1-9][0-9]*)
 <DOLAR>[])>]         { S();
                       return *yytext; }
 <DOLAR>[[:space:]]+  { S();
+                       yylval->str = strdup(yytext);
                        return TOK_HVML_JE_SPACE; }
 <DOLAR>.|\n          { unput(*yytext);
                        POP_STATE(); }

--- a/json-eval/src/hvml_je_scanner.l
+++ b/json-eval/src/hvml_je_scanner.l
@@ -112,6 +112,8 @@ LINTEGER 0|([1-9][0-9]*)
                       return TOK_HVML_JE_DOLAR2; }
 <DOLAR>[])>]         { S();
                       return *yytext; }
+<DOLAR>[[:space:]]+  { S();
+                       return TOK_HVML_JE_SPACE; }
 <DOLAR>.|\n          { unput(*yytext);
                        POP_STATE(); }
 

--- a/json-eval/src/hvml_je_scanner.l
+++ b/json-eval/src/hvml_je_scanner.l
@@ -74,7 +74,7 @@ LINTEGER 0|([1-9][0-9]*)
           PUSH_STATE(DOLAR);
           return TOK_HVML_JE_DOLAR2; }
 [^${]+  { S();
-          yylval->str = yytext;
+          yylval->str = strdup(yytext);
           return TOK_HVML_JE_TEXT; }
 .       { return -1; }
 
@@ -84,10 +84,10 @@ LINTEGER 0|([1-9][0-9]*)
 <DOLAR>[?@#%:]      { S();
                       return *yytext; }
 <DOLAR>{LTOKEN}     { S();
-                      yylval->str = yytext;
+                      yylval->str = strdup(yytext);
                       return TOK_HVML_JE_LTOKEN; }
 <DOLAR>{LINTEGER}   { S();
-                      yylval->str = yytext;
+                      yylval->str = strdup(yytext);
                       return TOK_HVML_JE_LINTEGER; }
 <DOLAR>[.]        { S();
                       return *yytext; }
@@ -120,7 +120,7 @@ LINTEGER 0|([1-9][0-9]*)
                   POP_STATE();
                   return *yytext; }
 <STR>[^"]+      { S();
-                  yylval->str = yytext;
+                  yylval->str = strdup(yytext);
                   return TOK_HVML_JE_LSTR; }
 
     /* no escape support yet */
@@ -128,7 +128,7 @@ LINTEGER 0|([1-9][0-9]*)
                   POP_STATE();
                   return *yytext; }
 <STR1>[^']+     { S();
-                  yylval->str = yytext;
+                  yylval->str = strdup(yytext);
                   return TOK_HVML_JE_LSTR; }
 
 %%

--- a/test/parser/CMakeLists.txt
+++ b/test/parser/CMakeLists.txt
@@ -4,7 +4,7 @@ if(NOT PYTHON3)
 endif()
 
 add_executable(hp main.c)
-target_link_libraries(hp hvml_parser_static hvml_jo_static)
+target_link_libraries(hp hvml_parser_static hvml_jo_static hvml_je_static)
 
 string(REPLACE "${PROJECT_SOURCE_DIR}" "" relative "${CMAKE_CURRENT_SOURCE_DIR}")
 

--- a/test/parser/main.c
+++ b/test/parser/main.c
@@ -32,6 +32,7 @@ static int process(FILE *in, const char *ext);
 static int process_hvml(FILE *in);
 static int process_json(FILE *in);
 static int process_utf8(FILE *in);
+static int process_jee(FILE *in);
 
 int main(int argc, char *argv[]) {
     if (argc == 1) return 0;
@@ -69,7 +70,9 @@ static const char* file_ext(const char *file) {
 }
 
 static int process(FILE *in, const char *ext) {
-    if (strcmp(ext, ".utf8")==0) {
+    if (strcmp(ext, ".jee")==0) {
+        return process_jee(in);
+    }else if (strcmp(ext, ".utf8")==0) {
         return process_utf8(in);
     }else if (strcmp(ext, ".json")==0) {
         return process_json(in);
@@ -149,5 +152,10 @@ static int process_utf8(FILE *in) {
     decoder = NULL;
 
     return ret ? 1 : 0;
+}
+
+static int process_jee(FILE *in) {
+    extern int dummy(hvml_dom_t **pdom, FILE *in);
+    return dummy(NULL, in);
 }
 

--- a/test/parser/test/je.jee
+++ b/test/parser/test/je.jee
@@ -1,0 +1,10 @@
+        $img_["哈喽世界"]
+        $_bal
+            $?.id $?.id $?.region
+                $?.avatar
+                $?.name
+                $?.attr.data-value $?.content[0].attr.src
+                $?.children[1].textContent $?.attr.data-region
+                    $global
+        $systemStatus
+


### PR DESCRIPTION
use flex/bison to generate json-eval parser, very much initially.
hvml_je_scanner.l: token scanner
hvml_je_parser.y: currently rules only, no action yet

to test:
1. build as usual
2. ./build/test/parser/hp test/parser/test/je.jee && echo yes
if you see `yes` in output, it seems parser works fine.
but I guess, failure is more often expected now. :(
