### PR TITLE
将 {{ }} （mustache表达式）的部分抽取出来单独处理

### DIFF
--- a/hvml-agent/HvmlEcho.cpp
+++ b/hvml-agent/HvmlEcho.cpp
@@ -15,21 +15,26 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+#include "HvmlRuntime.h"
 #include "HttpServer.h"
 #include "HvmlEcho.h"
 
-HvmlEcho::HvmlEcho(int listen_port)
+HvmlEcho::HvmlEcho(int listen_port, HvmlRuntime& runtime)
     : IHttpResponse(listen_port)
+    , runtime_(runtime)
 {
 }
 
 char* HvmlEcho::GetHttpResponse (int* info_len,
                                  const char* request)
 {
+    if (0 == strcmp(request, "/index")) {
+        size_t res_len = runtime_.GetIndexResponse(info_message_, INFO_MESSAGE_LEN);
+        return (res_len > 0) ? info_message_ : NULL;
+    }
 
     char info_format[] = "{ \"INFO_1\": %d, \"INFO_2\": %d, \"INFO_3\": %d }";
     *info_len = snprintf(info_message_, INFO_MESSAGE_LEN, info_format,
         1, 2, 3);
-
     return (*info_len > 0) ? info_message_ : NULL;
 }

--- a/hvml-agent/HvmlEcho.h
+++ b/hvml-agent/HvmlEcho.h
@@ -24,12 +24,13 @@
 class HvmlEcho : public IHttpResponse
 {
 public:
-    HvmlEcho(int listen_port);
+    HvmlEcho(int listen_port, HvmlRuntime& runtime);
     char* GetHttpResponse (int* info_len,
                            const char* request);
 
 private:
     char info_message_[INFO_MESSAGE_LEN];
+    HvmlRuntime& runtime_;
 };
 
 #endif //_hvml_echo_h_

--- a/hvml-agent/HvmlRuntime.cpp
+++ b/hvml-agent/HvmlRuntime.cpp
@@ -24,6 +24,7 @@ HvmlRuntime::HvmlRuntime(FILE *hvml_in_f)
     m_vdom = hvml_dom_load_from_stream(hvml_in_f);
     GetRuntime(m_vdom,
                &m_udom,
+               &m_mustache_part,
                &m_archetype_part,
                &m_iterate_part,
                &m_init_part,
@@ -34,8 +35,33 @@ HvmlRuntime::~HvmlRuntime()
 {
     if (m_vdom) hvml_dom_destroy(m_vdom);
     if (m_udom) hvml_dom_destroy(m_udom);
+    m_mustache_part.clear();
     m_archetype_part.clear();
     m_iterate_part.clear();
     m_init_part.clear();
     m_observe_part.clear();
+}
+
+
+static char html_filename[] = "index/index.html";
+
+size_t HvmlRuntime::GetIndexResponse(char* response,
+                                     size_t response_limit)
+{
+    if (! m_udom) return 0;
+
+    FILE *out = fopen(html_filename, "wb+");
+    if (! out) {
+        E("failed to create output file: %s", html_filename);
+        
+        return 0;
+    }
+
+    DumpUdomPart(m_udom, out);
+
+    fseek(out, 0, SEEK_SET);
+    size_t ret_len = fread(response, 1, response_limit, out);
+    response[ret_len] = '\0';
+    fclose(out);
+    return ret_len;
 }

--- a/hvml-agent/HvmlRuntime.cpp
+++ b/hvml-agent/HvmlRuntime.cpp
@@ -43,7 +43,7 @@ HvmlRuntime::~HvmlRuntime()
 }
 
 
-static char html_filename[] = "index/index.html";
+const char html_filename[] = "index/index.html";
 
 size_t HvmlRuntime::GetIndexResponse(char* response,
                                      size_t response_limit)
@@ -64,4 +64,50 @@ size_t HvmlRuntime::GetIndexResponse(char* response,
     response[ret_len] = '\0';
     fclose(out);
     return ret_len;
+}
+
+void HvmlRuntime::Refresh(void)
+{
+    TransformMustacheGroup();
+    TransformArchetypeGroup();
+    TransformIterateGroup();
+    TransformObserveGroup();
+}
+
+void HvmlRuntime::TransformMustacheGroup()
+{
+    for_each(m_mustache_part.begin(),
+             m_mustache_part.end(),
+             [&](mustache_t& item)->void{
+
+                 hvml_dom_t *dom = item.vdom;
+                 switch (hvml_dom_type(dom))
+                 {
+                     case MKDOT(D_ATTR): {
+                        const char *key = hvml_dom_attr_key(dom);
+                        const char *val = hvml_dom_attr_val(dom);
+                     }
+                     break;
+
+                     case MKDOT(D_TEXT): {
+                         const char *text = hvml_dom_text(dom);
+                     }
+                     break;
+                 }
+             });
+}
+
+void HvmlRuntime::TransformArchetypeGroup()
+{
+    ;
+}
+
+void HvmlRuntime::TransformIterateGroup()
+{
+    ;
+}
+
+void HvmlRuntime::TransformObserveGroup()
+{
+    ;
 }

--- a/hvml-agent/HvmlRuntime.h
+++ b/hvml-agent/HvmlRuntime.h
@@ -29,6 +29,8 @@ public:
     size_t GetIndexResponse(char* response,
                             size_t response_limit);
 
+    void Refresh(void);
+
 private:
     hvml_dom_t *m_vdom; // origin hvml dom
     hvml_dom_t *m_udom; // dom for display
@@ -37,6 +39,12 @@ private:
     IterateGroup_t   m_iterate_part;
     InitGroup_t      m_init_part;
     ObserveGroup_t   m_observe_part;
+
+private:
+    void TransformMustacheGroup();
+    void TransformArchetypeGroup();
+    void TransformIterateGroup();
+    void TransformObserveGroup();
 };
 
 #endif //_hvml_runtime_h_

--- a/hvml-agent/HvmlRuntime.h
+++ b/hvml-agent/HvmlRuntime.h
@@ -18,6 +18,7 @@
 #ifndef _hvml_runtime_h_
 #define _hvml_runtime_h_
 
+#include "interpreter/interpreter_basic.h"
 #include "interpreter/interpreter_runtime.h"
 
 class HvmlRuntime : public Interpreter_Runtime
@@ -25,10 +26,13 @@ class HvmlRuntime : public Interpreter_Runtime
 public:
     HvmlRuntime(FILE *hvml_in_f);
     ~HvmlRuntime();
+    size_t GetIndexResponse(char* response,
+                            size_t response_limit);
 
 private:
     hvml_dom_t *m_vdom; // origin hvml dom
     hvml_dom_t *m_udom; // dom for display
+    MustacheGroup_t  m_mustache_part;
     ArchetypeGroup_t m_archetype_part;
     IterateGroup_t   m_iterate_part;
     InitGroup_t      m_init_part;

--- a/hvml-agent/HvmlRuntime.h
+++ b/hvml-agent/HvmlRuntime.h
@@ -29,7 +29,7 @@ public:
     size_t GetIndexResponse(char* response,
                             size_t response_limit);
 
-    void Refresh(void);
+    bool Refresh(void);
 
 private:
     hvml_dom_t *m_vdom; // origin hvml dom
@@ -45,6 +45,7 @@ private:
     void TransformArchetypeGroup();
     void TransformIterateGroup();
     void TransformObserveGroup();
+    hvml_string_t TransformMustacheString(hvml_string_t& mustache_s);
 };
 
 #endif //_hvml_runtime_h_

--- a/hvml-agent/README.md
+++ b/hvml-agent/README.md
@@ -4,5 +4,4 @@ NOTICE: Install the ACE first, reference to the file:
 
 $ ./gen-make.sh
 $ make -f Makefile.hvml_agent
-$ ./copy-so.sh
 $ ./run-test.sh

--- a/hvml-agent/copy-so.sh
+++ b/hvml-agent/copy-so.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cp ../build/parser/src/libhvml_parser.so ./
-cp ../build/interpreter/src/libhvml_interpreter.so ./

--- a/hvml-agent/gen-make.sh
+++ b/hvml-agent/gen-make.sh
@@ -1,2 +1,5 @@
 #!/bin/bash
+cp ../build/parser/src/libhvml_parser.so ./
+cp ../build/interpreter/src/libhvml_interpreter.so ./
+
 $ACE_ROOT/bin/mpc.pl -type make hvml-agent.mpc

--- a/hvml-agent/hvml-agent.cpp
+++ b/hvml-agent/hvml-agent.cpp
@@ -47,6 +47,10 @@ int ACE_TMAIN(int argc, char* argv[])
     }
 
     HvmlRuntime runtime(hvml_in_f);
+    if (! runtime.Refresh()) {
+        E("failed to refresh HVML file: %s", file_in);
+        return 1;
+    }
 
     HvmlEcho http_echo(LISTEN_PORT, runtime);
     HttpServer::StartServer(&http_echo);

--- a/hvml-agent/hvml-agent.cpp
+++ b/hvml-agent/hvml-agent.cpp
@@ -48,7 +48,7 @@ int ACE_TMAIN(int argc, char* argv[])
 
     HvmlRuntime runtime(hvml_in_f);
 
-    HvmlEcho http_echo(LISTEN_PORT);
+    HvmlEcho http_echo(LISTEN_PORT, runtime);
     HttpServer::StartServer(&http_echo);
     ACE_DEBUG((LM_DEBUG, ACE_TEXT("Start HttpEcho\n")));
 

--- a/hvml-agent/index/calculator.hvml
+++ b/hvml-agent/index/calculator.hvml
@@ -3,7 +3,7 @@
     <head>
         <title>计算器</title>
 
-        <link rel="stylesheet" href="https://github.com/HVML/hvml-docs/raw/master/zh/calculator.css" />
+        <link rel="stylesheet" href="calculator.css" />
 
         <init as="buttons">
             [

--- a/hvml-agent/re-make.sh
+++ b/hvml-agent/re-make.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+make clean -f Makefile.hvml_agent
+make -f Makefile.hvml_agent

--- a/include/hvml/hvml_dom.h
+++ b/include/hvml/hvml_dom.h
@@ -65,7 +65,9 @@ hvml_dom_t* hvml_dom_select(hvml_dom_t *dom, const char *selector);
 
 void        hvml_dom_str_serialize(const char *str, size_t len, FILE *out);
 void        hvml_dom_attr_val_serialize(const char *str, size_t len, FILE *out);
-
+void        hvml_dom_attr_set_key(hvml_dom_t *dom, const char *key, size_t key_len);
+void        hvml_dom_attr_set_val(hvml_dom_t *dom, const char *val, size_t val_len);
+void        hvml_dom_set_text(hvml_dom_t *dom, const char *txt, size_t txt_len);
 
 HVML_DOM_TYPE hvml_dom_type(hvml_dom_t *dom);
 const char*   hvml_dom_tag_name(hvml_dom_t *dom);      // tag's name

--- a/include/interpreter/ext_tools.h
+++ b/include/interpreter/ext_tools.h
@@ -28,7 +28,8 @@ extern "C"
 #endif
 
 const char *file_ext(const char *file);
-int strnicmp(const char *, const char *, size_t);
+int strnicmp(const char *s1, const char *s2, size_t len);
+const char *find_mustache(const char *s, size_t *ret_len);
 
 #ifdef __cplusplus
 }

--- a/include/interpreter/ext_tools.h
+++ b/include/interpreter/ext_tools.h
@@ -30,6 +30,7 @@ extern "C"
 const char *file_ext(const char *file);
 int strnicmp(const char *s1, const char *s2, size_t len);
 const char *find_mustache(const char *s, size_t *ret_len);
+char *str_trim(char *s);
 
 #ifdef __cplusplus
 }

--- a/include/interpreter/ext_tools.h
+++ b/include/interpreter/ext_tools.h
@@ -18,6 +18,7 @@
 #ifndef _ext_tools_h_
 #define _ext_tools_h_
 
+#include "hvml/hvml_string.h"
 #include <string.h>
 #include <stddef.h>
 #include <ctype.h>
@@ -30,7 +31,11 @@ extern "C"
 const char *file_ext(const char *file);
 int strnicmp(const char *s1, const char *s2, size_t len);
 const char *find_mustache(const char *s, size_t *ret_len);
+const char *get_mustache_inner(const char *s, size_t *ret_len);
 char *str_trim(char *s);
+hvml_string_t replace_string(hvml_string_t replaced_s,
+                             hvml_string_t after_replaced_s,
+                             const char* orig_str);
 
 #ifdef __cplusplus
 }

--- a/include/interpreter/interpreter_runtime.h
+++ b/include/interpreter/interpreter_runtime.h
@@ -34,6 +34,28 @@
 #include <vector>
 using namespace std;
 
+typedef struct mustache_s {
+    hvml_string_t s_inner_str;
+    hvml_dom_t* vdom;
+    hvml_dom_t* udom_owner;
+    hvml_dom_t* udom;
+
+    mustache_s(const char* str_inner,
+               size_t      str_inner_len,
+               hvml_dom_t* vdom_in,
+               hvml_dom_t* udom_owner_in,
+               hvml_dom_t* udom_in)
+    : s_inner_str({NULL, 0})
+    , vdom(vdom_in)
+    , udom_owner(udom_owner_in)
+    , udom(udom_in)
+    {
+        hvml_string_set(&s_inner_str,
+                        str_inner,
+                        str_inner_len);
+    }
+} mustache_t;
+
 typedef struct archetype_s {
     hvml_string_t s_id;
     hvml_dom_t* vdom;
@@ -94,6 +116,7 @@ typedef struct observe_s {
     {}
 } observe_t;
 
+typedef vector<mustache_t>  MustacheGroup_t;
 typedef vector<archetype_t> ArchetypeGroup_t;
 typedef vector<iterate_t>   IterateGroup_t;
 typedef vector<init_t>      InitGroup_t;
@@ -105,6 +128,9 @@ class Interpreter_Runtime
 public:
     static void DumpUdomPart(hvml_dom_t* udom,
                              FILE *udom_part_f);
+
+    static void DumpMustachePart(MustacheGroup_t* mustache_part,
+                                 FILE *mustache_part_f);
 
     static void DumpArchetypePart(ArchetypeGroup_t* archetype_part,
                                   FILE *archetype_part_f);
@@ -118,8 +144,9 @@ public:
     static void DumpObservePart(ObserveGroup_t* observe_part,
                                 FILE *observe_part_f);
 
-    static void GetRuntime(hvml_dom_t* input_dom,
+    static void GetRuntime(hvml_dom_t*  input_dom,
                            hvml_dom_t** udom_part,
+                           MustacheGroup_t* mustache_part,
                            ArchetypeGroup_t* archetype_part,
                            IterateGroup_t* iterate_part,
                            InitGroup_t* init_part,
@@ -132,12 +159,19 @@ private:
                                     void *arg,
                                     int *breakout);
 
+    static void AddNewMustache(MustacheGroup_t* mustache_part,
+                               const char* str_inner,
+                               size_t      str_inner_len,
+                               hvml_dom_t* vdom,
+                               hvml_dom_t* udom_owner,
+                               hvml_dom_t* udom);
+
     static void AddNewArchetype(ArchetypeGroup_t* archetype_part,
-                                hvml_dom_t* dom,
+                                hvml_dom_t* vdom,
                                 hvml_dom_t* udom_owner);
 
     static void AddNewIterate(IterateGroup_t* iterate_part,
-                              hvml_dom_t* dom,
+                              hvml_dom_t* vdom,
                               hvml_dom_t* udom_owner);
 
     static void AddNewInit(InitGroup_t* init_part,

--- a/include/interpreter/interpreter_runtime.h
+++ b/include/interpreter/interpreter_runtime.h
@@ -38,23 +38,28 @@ using namespace std;
 
 typedef struct mustache_s {
     hvml_string_t s_inner_str;
+    hvml_string_t s_full_str;
     hvml_dom_t* vdom;
     hvml_dom_t* udom_owner;
     hvml_dom_t* udom;
 
-    mustache_s(const char* str_inner,
-               size_t      str_inner_len,
+    mustache_s(const char* str_mustache,
+               size_t      str_len,
                hvml_dom_t* vdom_in,
                hvml_dom_t* udom_owner_in,
                hvml_dom_t* udom_in)
     : s_inner_str({NULL, 0})
+    , s_full_str({NULL, 0})
     , vdom(vdom_in)
     , udom_owner(udom_owner_in)
     , udom(udom_in)
     {
+        hvml_string_set(&s_full_str,
+                        str_mustache,
+                        str_len);
         hvml_string_set(&s_inner_str,
-                        str_inner,
-                        str_inner_len);
+                        str_mustache + 2,
+                        str_len - 4);
         str_trim(s_inner_str.str);
         s_inner_str.len = strlen(s_inner_str.str);
     }

--- a/include/interpreter/interpreter_runtime.h
+++ b/include/interpreter/interpreter_runtime.h
@@ -27,10 +27,12 @@
 #include "hvml/hvml_log.h"
 #include "hvml/hvml_utf8.h"
 
+#include "ext_tools.h"
 #include "observe_for.h"
 #include "adverb_property.h"
 
-#include <string>
+#include <string.h>
+
 #include <vector>
 using namespace std;
 
@@ -53,6 +55,8 @@ typedef struct mustache_s {
         hvml_string_set(&s_inner_str,
                         str_inner,
                         str_inner_len);
+        str_trim(s_inner_str.str);
+        s_inner_str.len = strlen(s_inner_str.str);
     }
 } mustache_t;
 

--- a/interpreter/src/ext_tools.c
+++ b/interpreter/src/ext_tools.c
@@ -41,3 +41,18 @@ int strnicmp(const char *s1, const char *s2, size_t len)
 
     return (int)c1 - (int)c2;
 }
+
+const char *find_mustache(const char *s, size_t *ret_len)
+{
+    const char *ret = strstr(s, "{{");
+    if (ret) {
+        const char *end = strstr(ret, "}}");
+        if (end) {
+            if (ret_len) {
+                *ret_len = (end - ret);
+            }
+            return ret;
+        }
+    }
+    return NULL;
+}

--- a/interpreter/src/ext_tools.c
+++ b/interpreter/src/ext_tools.c
@@ -49,10 +49,30 @@ const char *find_mustache(const char *s, size_t *ret_len)
         const char *end = strstr(ret, "}}");
         if (end) {
             if (ret_len) {
-                *ret_len = (end - ret);
+                *ret_len = (end - ret + 2);
             }
             return ret;
         }
     }
     return NULL;
+}
+
+char *str_trim(char *s)
+{
+    char *p = s;
+    while (*p == ' ' || *p == '\t' && *p != '\0') p++;
+    if (*p == '\0') {
+        *s = '\0';
+        return s;
+    }
+    char *q = s;
+    do {
+        *q = *p;
+        q++;
+        p++;
+    } while (*p);
+    q --;
+    while (*q == ' ' || *q == '\t') q--;
+    *(q+1) ='\0';
+    return s;
 }

--- a/interpreter/src/interpreter_runtime.cpp
+++ b/interpreter/src/interpreter_runtime.cpp
@@ -17,8 +17,7 @@
 
 #include "interpreter/interpreter_runtime.h"
 #include <string.h>
-
-#include<algorithm> // for_each
+#include <algorithm> // for_each
 
 typedef struct TraverseParam_s {
     hvml_dom_t**      udom_pptr;
@@ -326,11 +325,11 @@ void Interpreter_Runtime::traverse_for_divide(hvml_dom_t *dom,
             A(u, "internal logic error");
 
             size_t mustache_str_len;
-            const char *mustache_str = find_mustache(val, &mustache_str_len);
-            if (mustache_str) {
+            const char *mustache_inner_str = find_mustache(val, &mustache_str_len);
+            if (mustache_inner_str) {
                 AddNewMustache(param->mustache_part,
-                               mustache_str + 2, // skip the "{{"
-                               mustache_str_len - 4,// skip the "}}"
+                               mustache_inner_str,
+                               mustache_str_len,
                                dom,
                                param->udom_curr_ptr,
                                u);
@@ -352,11 +351,11 @@ void Interpreter_Runtime::traverse_for_divide(hvml_dom_t *dom,
             A(u, "internal logic error");
 
             size_t mustache_str_len;
-            const char *mustache_str = find_mustache(text, &mustache_str_len);
-            if (mustache_str) {
+            const char *mustache_inner_str = find_mustache(text, &mustache_str_len);
+            if (mustache_inner_str) {
                 AddNewMustache(param->mustache_part,
-                               mustache_str + 2, // skip the "{{"
-                               mustache_str_len - 4,// skip the "}}"
+                               mustache_inner_str,
+                               mustache_str_len ,
                                dom,
                                param->udom_curr_ptr,
                                u);

--- a/interpreter/src/interpreter_runtime.cpp
+++ b/interpreter/src/interpreter_runtime.cpp
@@ -16,7 +16,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "interpreter/interpreter_runtime.h"
-#include "interpreter/ext_tools.h"
 #include <string.h>
 
 #include<algorithm> // for_each
@@ -331,7 +330,7 @@ void Interpreter_Runtime::traverse_for_divide(hvml_dom_t *dom,
             if (mustache_str) {
                 AddNewMustache(param->mustache_part,
                                mustache_str + 2, // skip the "{{"
-                               mustache_str_len - 2,
+                               mustache_str_len - 4,// skip the "}}"
                                dom,
                                param->udom_curr_ptr,
                                u);
@@ -357,7 +356,7 @@ void Interpreter_Runtime::traverse_for_divide(hvml_dom_t *dom,
             if (mustache_str) {
                 AddNewMustache(param->mustache_part,
                                mustache_str + 2, // skip the "{{"
-                               mustache_str_len - 2,
+                               mustache_str_len - 4,// skip the "}}"
                                dom,
                                param->udom_curr_ptr,
                                u);

--- a/interpreter/src/interpreter_runtime.cpp
+++ b/interpreter/src/interpreter_runtime.cpp
@@ -51,6 +51,7 @@ typedef struct TraverseParam_s {
 void Interpreter_Runtime::DumpUdomPart(hvml_dom_t* udom,
                                        FILE *udom_part_f)
 {
+    fprintf(udom_part_f, "<!DOCTYPE html>\n");
     hvml_dom_printf(udom, udom_part_f);
 }
 
@@ -262,12 +263,19 @@ void Interpreter_Runtime::traverse_for_divide(hvml_dom_t *dom,
                     }
                     else {
                         I("----- A <udom-%s> ---", tag_name);
-                        hvml_dom_t* u = hvml_dom_add_tag(param->udom_curr_ptr,
-                                        tag_name, strlen(tag_name));
-                        A(u, "internal logic error");
-                        param->udom_curr_ptr = u;
                         if (0 == strcmp("hvml", tag_name)) {
+                            tag_name = "html";
+                            hvml_dom_t* u = hvml_dom_add_tag(param->udom_curr_ptr,
+                                            tag_name, strlen(tag_name));
+                            A(u, "internal logic error");
+                            param->udom_curr_ptr = u;
                             *(param->udom_pptr) = u;
+                        }
+                        else {
+                            hvml_dom_t* u = hvml_dom_add_tag(param->udom_curr_ptr,
+                                        tag_name, strlen(tag_name));
+                            A(u, "internal logic error");
+                            param->udom_curr_ptr = u;
                         }
                     }
  

--- a/parser/src/hvml_dom.c
+++ b/parser/src/hvml_dom.c
@@ -323,6 +323,21 @@ void hvml_dom_attr_val_serialize(const char *str, size_t len, FILE *out) {
     }
 }
 
+void hvml_dom_attr_set_key(hvml_dom_t *dom, const char *key, size_t key_len) {
+    A((dom->dt == MKDOT(D_ATTR)), "internal logic error");
+    hvml_string_set(&dom->attr.key, key, key_len);
+}
+
+void hvml_dom_attr_set_val(hvml_dom_t *dom, const char *val, size_t val_len) {
+    A((dom->dt == MKDOT(D_ATTR)), "internal logic error");
+    hvml_string_set(&dom->attr.key, val, val_len);
+}
+
+void hvml_dom_set_text(hvml_dom_t *dom, const char *txt, size_t txt_len) {
+    A((dom->dt == MKDOT(D_TEXT)), "internal logic error");
+    hvml_string_set(&dom->txt.txt, txt, txt_len);
+}
+
 HVML_DOM_TYPE hvml_dom_type(hvml_dom_t *dom) {
     return dom->dt;
 }

--- a/test/interpreter/main.cpp
+++ b/test/interpreter/main.cpp
@@ -21,6 +21,7 @@
 #include "hvml/hvml_json_parser.h"
 #include "hvml/hvml_log.h"
 #include "hvml/hvml_utf8.h"
+#include "hvml/hvml_string.h"
 
 #include "interpreter/ext_tools.h"
 #include "interpreter/interpreter_basic.h"
@@ -185,6 +186,28 @@ int main(int argc, char *argv[])
     fclose(init_part_f);
     fclose(observe_part_f);
     fclose(vdom_part_f);
+
+    I("----------------- Test replace_string");
+    const char* replaced_str = "Tom";
+    const char* after_replaced_str = "my old friend";
+    const char* orig_str = "Hello Tom, you looks so good !";
+    hvml_string_t replaced_s = {NULL, 0};
+    hvml_string_t after_replaced_s = {NULL, 0};
+    hvml_string_set (&replaced_s, replaced_str, strlen(replaced_str));
+    hvml_string_set (&after_replaced_s, after_replaced_str, strlen(after_replaced_str));
+    hvml_string_t replace_ret = replace_string(replaced_s,
+                                       after_replaced_s,
+                                       orig_str);
+    I("replaced_s: %s\n", replaced_s);
+    I("after_replaced_s: %s\n", after_replaced_s);
+    I("orig_str: %s\n", orig_str);
+    I("result: %s\n", replace_ret.str);
+    hvml_string_clear(&replaced_s);
+    hvml_string_clear(&after_replaced_s);
+    hvml_string_clear(&replace_ret);
+    I("----------------- Test replace_string end.");
+
+
 
     if (ret) return ret;
     return 0;

--- a/test/interpreter/main.cpp
+++ b/test/interpreter/main.cpp
@@ -36,19 +36,23 @@ using namespace std;
 static int process(FILE *in, const char *ext);
 static int process_hvml(FILE *in,
                         FILE *out,
+                        FILE *mustache_part_f,
                         FILE *archetype_part_f,
                         FILE *iterate_part_f,
                         FILE *init_part_f,
-                        FILE *observe_part_f);
+                        FILE *observe_part_f,
+                        FILE *vdom_f);
 static int process_json(FILE *in);
 static int process_utf8(FILE *in);
 
 #define PATH_MAX    512
 static char output_filename[PATH_MAX+1];
+static char mustache_part_filename[PATH_MAX+1];
 static char archetype_part_filename[PATH_MAX+1];
 static char iterate_part_filename[PATH_MAX+1];
 static char init_part_filename[PATH_MAX+1];
 static char observe_part_filename[PATH_MAX+1];
+static char vdom_filename[PATH_MAX+1];
 
 int main(int argc, char *argv[])
 {
@@ -73,15 +77,19 @@ int main(int argc, char *argv[])
 
     size_t fname_len = min ((size_t)(PATH_MAX - 6), strlen(file_in) - 5);
     strncpy(output_filename, file_in, fname_len);
+    strncpy(mustache_part_filename, file_in, fname_len);
     strncpy(archetype_part_filename, file_in, fname_len);
     strncpy(iterate_part_filename, file_in, fname_len);
     strncpy(init_part_filename, file_in, fname_len);
     strncpy(observe_part_filename, file_in, fname_len);
+    strncpy(vdom_filename, file_in, fname_len);
     strncat(output_filename, ".udom_part.html", PATH_MAX);
+    strncat(mustache_part_filename, ".mustache_part.xml", PATH_MAX);
     strncat(archetype_part_filename, ".archetype_part.xml", PATH_MAX);
     strncat(iterate_part_filename, ".iterate_part.xml", PATH_MAX);
     strncat(init_part_filename, ".init_part.xml", PATH_MAX);
     strncat(observe_part_filename, ".observe_part.xml", PATH_MAX);
+    strncat(vdom_filename, ".vdom_part.xml", PATH_MAX);
 
     FILE *in = fopen(file_in, "rb");
     if (! in) {
@@ -96,11 +104,20 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    FILE *mustache_part_f = fopen(mustache_part_filename, "wb");
+    if (! mustache_part_f) {
+        E("failed to create file: %s", mustache_part_filename);
+        fclose(in);
+        fclose(out);
+        return 1;
+    }
+
     FILE *archetype_part_f = fopen(archetype_part_filename, "wb");
     if (! archetype_part_f) {
         E("failed to create file: %s", archetype_part_filename);
         fclose(in);
         fclose(out);
+        fclose(mustache_part_f);
         return 1;
     }
 
@@ -109,6 +126,7 @@ int main(int argc, char *argv[])
         E("failed to create file: %s", iterate_part_filename);
         fclose(in);
         fclose(out);
+        fclose(mustache_part_f);
         fclose(archetype_part_f);
         return 1;
     }
@@ -118,6 +136,7 @@ int main(int argc, char *argv[])
         E("failed to create file: %s", init_part_filename);
         fclose(in);
         fclose(out);
+        fclose(mustache_part_f);
         fclose(archetype_part_f);
         fclose(iterate_part_f);
         return 1;
@@ -128,26 +147,44 @@ int main(int argc, char *argv[])
         E("failed to create file: %s", observe_part_filename);
         fclose(in);
         fclose(out);
+        fclose(mustache_part_f);
         fclose(archetype_part_f);
         fclose(iterate_part_f);
         fclose(init_part_f);
         return 1;
     }
 
+    FILE *vdom_part_f = fopen(vdom_filename, "wb");
+    if (! vdom_part_f) {
+        E("failed to create file: %s", vdom_filename);
+        fclose(in);
+        fclose(out);
+        fclose(mustache_part_f);
+        fclose(archetype_part_f);
+        fclose(iterate_part_f);
+        fclose(init_part_f);
+        fclose(observe_part_f);
+        return 1;
+    }
+
     I("processing file: %s", file_in);
     int ret = process_hvml(in, 
                            out,
+                           mustache_part_f,
                            archetype_part_f,
                            iterate_part_f,
                            init_part_f,
-                           observe_part_f);
+                           observe_part_f,
+                           vdom_part_f);
 
     fclose(in);
     fclose(out);
+    fclose(mustache_part_f);
     fclose(archetype_part_f);
     fclose(iterate_part_f);
     fclose(init_part_f);
     fclose(observe_part_f);
+    fclose(vdom_part_f);
 
     if (ret) return ret;
     return 0;
@@ -155,18 +192,21 @@ int main(int argc, char *argv[])
 
 static int process_hvml(FILE *in,
                         FILE *output_hvml_f,
+                        FILE *mustache_part_f,
                         FILE *archetype_part_f,
                         FILE *iterate_part_f,
                         FILE *init_part_f,
-                        FILE *observe_part_f)
+                        FILE *observe_part_f,
+                        FILE *vdom_part_f)
 {
     hvml_dom_t *dom = hvml_dom_load_from_stream(in);
     if (dom)
     {
         // This is a test, print as origin file is.
-        //Interpreter_Basic::GetOutput(dom, output_hvml_f);
+        //Interpreter_Basic::GetOutput(dom, vdom_part_f);
 
         hvml_dom_t*      udom_part = NULL;
+        MustacheGroup_t  mustache_part;
         ArchetypeGroup_t archetype_part;
         IterateGroup_t   iterate_part;
         InitGroup_t      init_part;
@@ -175,6 +215,7 @@ static int process_hvml(FILE *in,
         I("................. GetRuntime");
         Interpreter_Runtime::GetRuntime(dom,
                                         &udom_part,
+                                        &mustache_part,
                                         &archetype_part,
                                         &iterate_part,
                                         &init_part,
@@ -182,7 +223,10 @@ static int process_hvml(FILE *in,
 
         I("................. DumpUdomPart");
         Interpreter_Runtime::DumpUdomPart(udom_part,
-                                          output_hvml_f);
+                                         output_hvml_f);
+        I("................. DumpMustachePart");
+        Interpreter_Runtime::DumpMustachePart(&mustache_part,
+                                              mustache_part_f);
         I("................. DumpArchetypePart");
         Interpreter_Runtime::DumpArchetypePart(&archetype_part,
                                                archetype_part_f);
@@ -195,6 +239,10 @@ static int process_hvml(FILE *in,
         I("................. DumpObservePart");
         Interpreter_Runtime::DumpObservePart(&observe_part,
                                              observe_part_f);
+
+        I("................. Dump vdom part");
+        // Test whether the original dom is damaged.
+        Interpreter_Basic::GetOutput(dom, vdom_part_f);
 
         hvml_dom_destroy(dom);
         hvml_dom_destroy(udom_part);


### PR DESCRIPTION
mustache_part 相当于在 vDOM 和 uDOM 之间架了一个桥梁，根据 vDOM 的 mustache 去生成 uDOM 那边对应的 D_TEXT 的 txt 或 D_ATTR 的 val。转换 mustache 表达式的部分还没有添加，打算放在 hvml-agent 里面去实现。